### PR TITLE
Perf: cache star glow sprites + fix pause button + move time controls

### DIFF
--- a/css/starfield.css
+++ b/css/starfield.css
@@ -54,31 +54,31 @@ body {
 }
 #loading.hidden { opacity: 0; pointer-events: none; }
 
-/* --- Clock panel (top-right) --- */
+/* --- Clock + time controls (bottom-center) --- */
 
 #clock-panel {
   position: fixed;
-  top: 0.75rem;
-  right: 0.75rem;
+  bottom: 3rem;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 10;
   background: rgba(0,0,0,0.7);
-  padding: 0.5rem 0.75rem;
-  border-radius: 4px;
+  padding: 0.4rem 0.75rem;
+  border-radius: 4px 4px 0 0;
   font-size: 0.7rem;
   line-height: 1.6;
   pointer-events: none;
-  text-align: right;
+  text-align: center;
   font-family: monospace;
   color: #aaa;
 }
 #clock-time { font-size: 1.1rem; color: #ccc; }
 
-/* --- Time controls (under clock) --- */
-
 #time-controls {
   position: fixed;
-  top: 3.5rem;
-  right: 0.75rem;
+  bottom: 0.75rem;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 10;
   display: flex;
   gap: 0.25rem;

--- a/js/viewer/controls.js
+++ b/js/viewer/controls.js
@@ -36,11 +36,17 @@ export function advanceTime() {
 export function togglePause() {
   if (timeSpeed === 0) {
     timeSpeed = _prevTimeSpeed || 1;
-    _lastRealTime = Date.now(); // prevent stale elapsed accumulation on resume
+    _lastRealTime = Date.now();
   } else {
     _prevTimeSpeed = timeSpeed;
     timeSpeed = 0;
   }
+  _syncPauseButton();
+}
+
+function _syncPauseButton() {
+  const btn = document.getElementById('btn-pause');
+  if (btn) btn.textContent = timeSpeed === 0 ? '\u25B6' : '||';
 }
 
 /** Step speed up (dir=1) or down (dir=-1) through SPEED_STEPS. */
@@ -51,6 +57,7 @@ export function changeSpeed(dir) {
   const next = idx + dir;
   if (next >= 0 && next < SPEED_STEPS.length) timeSpeed = SPEED_STEPS[next];
   if (wasPaused && timeSpeed !== 0) _lastRealTime = Date.now();
+  _syncPauseButton();
 }
 
 /** Reset to real-time (speed=1, offset=0). */
@@ -58,6 +65,7 @@ export function resetTime() {
   timeOffsetMs = 0;
   timeSpeed = 1;
   _lastRealTime = Date.now();
+  _syncPauseButton();
 }
 
 /** Wire up the time control DOM buttons. */

--- a/js/viewer/render-objects.js
+++ b/js/viewer/render-objects.js
@@ -11,6 +11,29 @@ import { D2R, BELOW_HORIZON_DIM, MAG_FADE_BAND, reducedMotion } from './config.j
 import { bvToColor, magToRadius, magToAlpha, edgeFade, fovMagLimit } from './visual.js';
 import { projectStar } from './camera.js';
 
+// --- Glow sprite cache ---
+// Pre-rendered radial glow textures keyed by "R,G,B" string.
+// Eliminates ~20 createRadialGradient() calls per frame for bright stars.
+
+const _glowCache = new Map();
+const GLOW_SIZE = 64; // sprite diameter in px
+
+function getGlowSprite(rgb) {
+  let sprite = _glowCache.get(rgb);
+  if (sprite) return sprite;
+  const c = document.createElement('canvas');
+  c.width = GLOW_SIZE; c.height = GLOW_SIZE;
+  const g = c.getContext('2d');
+  const half = GLOW_SIZE / 2;
+  const grad = g.createRadialGradient(half, half, half * 0.1, half, half, half);
+  grad.addColorStop(0, `rgba(${rgb},0.35)`);
+  grad.addColorStop(1, `rgba(${rgb},0)`);
+  g.fillStyle = grad;
+  g.fillRect(0, 0, GLOW_SIZE, GLOW_SIZE);
+  _glowCache.set(rgb, c);
+  return c;
+}
+
 // --- Stars ---
 
 /**
@@ -56,13 +79,10 @@ export function renderStars(rc, stars, screenBuf) {
 
     if (mag < 2.0 && !p.belowHorizon) {
       const glowR = r * 5;
-      const grad = ctx.createRadialGradient(px, py, r * 0.5, px, py, glowR);
-      grad.addColorStop(0, `rgba(${rgb},${a * 0.35})`);
-      grad.addColorStop(1, `rgba(${rgb},0)`);
-      ctx.beginPath();
-      ctx.arc(px, py, glowR, 0, Math.PI * 2);
-      ctx.fillStyle = grad;
-      ctx.fill();
+      const sprite = getGlowSprite(rgb);
+      ctx.globalAlpha = a;
+      ctx.drawImage(sprite, px - glowR, py - glowR, glowR * 2, glowR * 2);
+      ctx.globalAlpha = 1;
     }
 
     const bi = count * 3;

--- a/refactor_roadmap.md
+++ b/refactor_roadmap.md
@@ -239,13 +239,13 @@ battery life, thermal throttle, and scrolling smoothness on weaker devices.
 - [x] Also removed from DSOs, Sun, Moon, planets, constellations, labels, cardinals, twilight
 - [x] **Eliminates ~5,000+ string allocations per frame**
 
-### Priority 3: Pre-render glow sprites (~45 min, medium impact)
+### Priority 3: Pre-render glow sprites (~45 min, medium impact) — DONE
 
-- [ ] `createRadialGradient()` allocates a new CanvasGradient object per bright star per frame
-- [ ] ~20 bright stars + ~9 planets + Sun + Moon = ~30 gradient allocations per frame, all GC'd
-- [ ] Fix: at init, pre-render a unit glow circle for each color band to a small offscreen canvas
-- [ ] At render time, use `drawImage()` at the right position and scale instead of gradient
-- [ ] **Eliminates ~30 CanvasGradient allocations per frame + GC pressure**
+- [x] `createRadialGradient()` allocated a new CanvasGradient object per bright star per frame
+- [x] Fix: glow sprites cached per color in offscreen canvases, drawn with `drawImage()` + `globalAlpha`
+- [x] Sprites created lazily on first use and reused every subsequent frame (~8-10 unique colors)
+- [x] Planets/Sun/Moon gradients left as-is (~11 per frame, not worth the complexity)
+- [x] **Eliminates ~20 CanvasGradient allocations per frame for bright stars**
 
 ### Priority 4: Reduce Milky Way draw calls (~30 min, medium impact)
 

--- a/starfield.html
+++ b/starfield.html
@@ -22,7 +22,7 @@
   <div id="time-controls">
     <span id="live-indicator" class="live">LIVE</span>
     <button id="btn-rewind" title="Rewind">&lt;&lt;</button>
-    <button id="btn-pause" title="Pause/Play (Space)">ll</button>
+    <button id="btn-pause" title="Pause/Play (Space)">||</button>
     <button id="btn-forward" title="Fast Forward">&gt;&gt;</button>
     <button id="btn-now" title="Return to Now">Now</button>
     <span id="time-speed"></span>


### PR DESCRIPTION
## Summary

**Performance:**
- Bright star glows (~20/frame) now use pre-rendered offscreen canvas sprites keyed by RGB color string
- `createRadialGradient()` replaced with `drawImage()` + `globalAlpha` — eliminates ~20 gradient allocs/frame
- Sprites are lazily created on first use and cached for all subsequent frames

**UI fixes:**
- Pause button: changed from `ll` to `||`, toggles to `▶` when paused
- Button text syncs on all state changes (pause/play, speed change, reset to Now)
- Clock panel and time controls moved from top-right to bottom-center of the viewport

## Test plan

- [ ] Star glows render correctly for bright stars (Sirius, Betelgeuse, Rigel, etc.)
- [ ] Pause button shows `||` when playing, `▶` when paused
- [ ] Button updates when pressing Space, clicking <</>>/Now
- [ ] Clock and time controls are centered at the bottom of the screen
- [ ] No console errors

**Test locally:** `python3 -m http.server 8765` then open `http://localhost:8765/starfield.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)