### PR TITLE
Fix: ephemeris rewind bug + clock/controls layout

### DIFF
--- a/css/starfield.css
+++ b/css/starfield.css
@@ -54,25 +54,26 @@ body {
 }
 #loading.hidden { opacity: 0; pointer-events: none; }
 
-/* --- Clock + time controls (bottom-center) --- */
+/* --- Clock panel (top-right) --- */
 
 #clock-panel {
   position: fixed;
-  bottom: 3rem;
-  left: 50%;
-  transform: translateX(-50%);
+  top: 0.75rem;
+  right: 0.75rem;
   z-index: 10;
   background: rgba(0,0,0,0.7);
-  padding: 0.4rem 0.75rem;
-  border-radius: 4px 4px 0 0;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
   font-size: 0.7rem;
   line-height: 1.6;
   pointer-events: none;
-  text-align: center;
+  text-align: right;
   font-family: monospace;
   color: #aaa;
 }
 #clock-time { font-size: 1.1rem; color: #ccc; }
+
+/* --- Time controls (bottom-center) --- */
 
 #time-controls {
   position: fixed;

--- a/js/starfield.js
+++ b/js/starfield.js
@@ -155,7 +155,8 @@ let _cachedMoon = null;
 let _lastEphemJD = 0;
 
 function updateEphemeris(jd) {
-  if (jd - _lastEphemJD > 1 / 1440) {
+  // Math.abs so positions refresh during rewind (negative speed), not just forward
+  if (Math.abs(jd - _lastEphemJD) > 1 / 1440) {
     _cachedPlanets = planetPositions(jd);
     _cachedSun = sunPosition(jd);
     _cachedMoon = moonPosition(jd);


### PR DESCRIPTION
## Summary

- **Rewind bug fix**: `updateEphemeris()` only refreshed when `jd` increased by >1 minute. During rewind (negative speed), `jd` decreases so the cache never updated, causing stale planet/Sun/Moon positions. Fixed with `Math.abs(jd - _lastEphemJD)`.
- **Layout**: Clock panel (time + date) moved to top-right in its own box. Time controls (LIVE, <<, ||, >>, Now) stay bottom-center.

## Test plan

- [x] Rewind time (click << a few times) — planets/Sun/Moon should move backwards smoothly
- [x] Clock shows top-right corner
- [x] Time controls show bottom-center
- [x] Both in separate panels with their own backgrounds

**Test locally:** `python3 -m http.server 8765` → `http://localhost:8765/starfield.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)